### PR TITLE
maint: Sync master with main

### DIFF
--- a/.github/workflows/sync-master.yml
+++ b/.github/workflows/sync-master.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"  # Runs every night at midnight UTC
   workflow_dispatch:  # Allows manual triggering
 
+permissions:
+  contents: write  # Grants write access to push changes
+
 jobs:
   sync-branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-master.yml
+++ b/.github/workflows/sync-master.yml
@@ -1,0 +1,27 @@
+name: Sync master with main
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs every night at midnight UTC
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync master with main
+        run: |
+          git checkout master
+          git pull origin master
+          git merge origin/main --no-edit
+          git push origin master


### PR DESCRIPTION
For this workflow to work, I need to disable push protection in `master` branch. Is there any way of allowing github bot to bypass the rules? @RobPasMue 