### PR TITLE
Static Mixer case including unitless parameters

### DIFF
--- a/pyfluent/static_mixer/StaticMixer_Parameters_unitless.cas.h5
+++ b/pyfluent/static_mixer/StaticMixer_Parameters_unitless.cas.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cff8655495c586bd3dc564ba0f11b4f942a0ca78c6f5b78d8bfa8f733656107
+size 11403600


### PR DESCRIPTION
This Fluent case file is required for an OptisLang integration test of unitless input and output parameters in PyFluent.