### PR TITLE
Static Mixer case including unitless parameters

### DIFF
--- a/pyfluent/static_mixer/Static_Mixer_Parameters_unitless.cas.h5
+++ b/pyfluent/static_mixer/Static_Mixer_Parameters_unitless.cas.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2889eb630a958004060e6e9578d0bde193f06c4132c49e086817d0b3918ef25c
+size 3693614


### PR DESCRIPTION
This Fluent case file is required for an OptisLang integration test of unitless input and output parameters in PyFluent. The case is based on Fluent Tutorial 10 - "Performing Parametric Analyses in Ansys Fluent"- with unitless input and output parameters added.